### PR TITLE
推移グラフ横軸の目盛りの位置の修正

### DIFF
--- a/frontend/src/components/charts/Co2Chart/index.tsx
+++ b/frontend/src/components/charts/Co2Chart/index.tsx
@@ -1,5 +1,8 @@
 import { trendDatumUnixtime } from "@/types";
-import { calculateTrendMovingAverage } from "@/utils/helpers";
+import {
+  calculateTimeTicks,
+  calculateTrendMovingAverage,
+} from "@/utils/helpers";
 import { Box, Typography } from "@mui/material";
 import dayjs from "dayjs";
 import {
@@ -24,6 +27,12 @@ export function Co2Chart({ co2Trend }: Co2ChartProps) {
   let co2MaTrend: trendDatumUnixtime[] = [];
   co2MaTrend = calculateTrendMovingAverage(co2Trend, 30);
 
+  let [tsMin, tsMax] = [0, 0];
+  if (co2Trend.length > 0) {
+    tsMin = co2Trend[co2Trend.length - 1].timestamp;
+    tsMax = co2Trend[0].timestamp;
+  }
+
   return (
     <Box sx={{ width: "100%" }}>
       <Box sx={{ marginBottom: "1.3rem" }}>
@@ -35,7 +44,7 @@ export function Co2Chart({ co2Trend }: Co2ChartProps) {
             dataKey="timestamp"
             type="number"
             domain={["dataMin", "dataMax"]}
-            tickCount={12}
+            ticks={calculateTimeTicks(tsMin, tsMax)}
             tickLine={false}
             tick={{ fontSize: "1.2rem", fontWeight: "lighter" }}
             tickFormatter={(unixTime) => dayjs.unix(unixTime).format("hA")}

--- a/frontend/src/components/charts/TempHumidChart/index.tsx
+++ b/frontend/src/components/charts/TempHumidChart/index.tsx
@@ -1,4 +1,5 @@
 import { trendDatumUnixtime } from "@/types";
+import { calculateTimeTicks } from "@/utils/helpers";
 import { Box, Typography } from "@mui/material";
 import dayjs from "dayjs";
 import {
@@ -24,6 +25,12 @@ export function TempHumidChart({
   temperatureTrend,
   humidityTrend,
 }: TempHumidChartProps) {
+  let [tsMin, tsMax] = [0, 0];
+  if (temperatureTrend.length > 0) {
+    tsMin = temperatureTrend[temperatureTrend.length - 1].timestamp;
+    tsMax = temperatureTrend[0].timestamp;
+  }
+
   return (
     <Box sx={{ width: "100%" }}>
       <Box sx={{ marginBottom: "1.3rem" }}>
@@ -35,7 +42,7 @@ export function TempHumidChart({
             dataKey="timestamp"
             type="number"
             domain={["dataMin", "dataMax"]}
-            tickCount={12}
+            ticks={calculateTimeTicks(tsMin, tsMax)}
             tickLine={false}
             tick={{ fontSize: "1.2rem", fontWeight: "lighter" }}
             tickFormatter={(unixTime) => dayjs.unix(unixTime).format("hA")}

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -8,6 +8,17 @@ export const timestampToUnixtime = (item: trendDatum): trendDatumUnixtime => {
   };
 };
 
+export const calculateTimeTicks = (min: number, max: number):number[] => {
+  const step = 3600;
+  const start = min - (min%step) + step;
+  let ret = [];
+  for (let t = start; t < max; t += step) {
+    ret.push(t);
+  }
+
+  return ret;
+}
+
 export const rollTimeSeries = (
   target: trendDatumUnixtime[],
   newValue: trendDatumUnixtime


### PR DESCRIPTION
目盛りの位置を毎時00分のところになるよう修正
グラフの表示範囲でtimestamp: int が3600で割れるところに表示するようにしました