### PR TITLE
気温湿度グラフのTooltipの値が入れ替わる問題の修正

### DIFF
--- a/frontend/src/components/charts/Co2Chart/index.tsx
+++ b/frontend/src/components/charts/Co2Chart/index.tsx
@@ -61,7 +61,7 @@ const renderCustomLegendText = (value: string) => {
   return <span style={{ color: "#666666", fontSize: "1.2rem" }}>{value}</span>;
 };
 
-type MargedCo2Datum = {
+type MergedCo2Datum = {
   timestamp: number;
   co2: number;
   ma: number | undefined;
@@ -76,9 +76,8 @@ export function Co2Chart({ co2Trend }: Co2ChartProps) {
     co2Trend,
     30
   );
-
   // Tooltipの表示を適切にするため、co2Trendとco2MaTrendの2系列を統合する
-  const margedCo2Series: MargedCo2Datum[] = co2Trend.map((item) => {
+  const mergedCo2Series: MergedCo2Datum[] = co2Trend.map((item) => {
     const match = co2MaTrend.find((i) => i.timestamp == item.timestamp);
     return {
       timestamp: item.timestamp,
@@ -126,7 +125,7 @@ export function Co2Chart({ co2Trend }: Co2ChartProps) {
           />
           <Tooltip content={<Co2Tooltip />} />
           <Line
-            data={margedCo2Series}
+            data={mergedCo2Series}
             name="二酸化炭素濃度[ppm]"
             type="monotone"
             dataKey="co2"
@@ -136,7 +135,7 @@ export function Co2Chart({ co2Trend }: Co2ChartProps) {
             isAnimationActive={false}
           />
           <Line
-            data={margedCo2Series}
+            data={mergedCo2Series}
             name="30分間移動平均[ppm]"
             type="monotone"
             dataKey="ma"

--- a/frontend/src/components/charts/TempHumidChart/index.tsx
+++ b/frontend/src/components/charts/TempHumidChart/index.tsx
@@ -55,6 +55,12 @@ const TempHumidTooltip = ({
   );
 };
 
+type MergedTempHumidDatum = {
+  timestamp: number;
+  temperature: number;
+  humidity: number | undefined;
+};
+
 type TempHumidChartProps = {
   temperatureTrend: trendDatumUnixtime[];
   humidityTrend: trendDatumUnixtime[];
@@ -64,6 +70,18 @@ export function TempHumidChart({
   temperatureTrend,
   humidityTrend,
 }: TempHumidChartProps) {
+  // Tooltipの表示を適切にするため、気温と湿度の2系列を統合する
+  const mergedTempHumidSeries: MergedTempHumidDatum[] = temperatureTrend.map(
+    (item) => {
+      const match = humidityTrend.find((i) => i.timestamp == item.timestamp);
+      return {
+        timestamp: item.timestamp,
+        temperature: item.value,
+        humidity: match?.value,
+      };
+    }
+  );
+
   let [tsMin, tsMax] = [0, 0];
   if (temperatureTrend.length > 0) {
     tsMin = temperatureTrend[temperatureTrend.length - 1].timestamp;
@@ -114,10 +132,10 @@ export function TempHumidChart({
           />
           <Tooltip content={<TempHumidTooltip />} />
           <Line
-            data={temperatureTrend}
+            data={mergedTempHumidSeries}
             name="気温[℃]"
             type="monotone"
-            dataKey="value"
+            dataKey="temperature"
             stroke="#ff8c00"
             strokeWidth={3}
             dot={false}
@@ -125,10 +143,10 @@ export function TempHumidChart({
             yAxisId="left"
           />
           <Line
-            data={humidityTrend}
+            data={mergedTempHumidSeries}
             name="湿度[%]"
             type="monotone"
-            dataKey="value"
+            dataKey="humidity"
             stroke="#4169e1"
             strokeWidth={3}
             dot={false}


### PR DESCRIPTION
気温湿度もCO2濃度グラフと同様に2つの配列を1つにまとめて扱うようにしました。
多分これで修正されると思います